### PR TITLE
Update install_bitfeed.sh

### DIFF
--- a/install/install_bitfeed.sh
+++ b/install/install_bitfeed.sh
@@ -123,6 +123,19 @@ echo -e "${G}Done.${NC}"
 
 #-----------------------------------------------------------------
 
+# fix base58 compile error in Debian 12 and Ubuntu 23.04
+NAME=$(cat /etc/os-release | grep ^ID= | cut -d '=' -f 2)
+VER=$(cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2)
+VER=${VER#\"}               # Remove optional leading "
+VER=${VER%\"}               # remove trailing "
+#echo $NAME
+#echo $VER
+if ([ "$NAME" = "debian" ] && [ "$VER" = "12" ]) || ([ "$NAME" = "ubuntu" ] && [ "$VER" = "23.04" ]); then
+  #echo "true"
+  sed -i.bak -e '125,131d' "${BITFEED_DIR}"/server/bitcoinex/lib/base58.ex
+fi
+#-----------------------------------------------------------------
+
 #
 ### build the bitfeed backend part
 #


### PR DESCRIPTION
- dirty fix for compile error in debian 12 and ubuntu 23.04 for bitcoinex/lib/base58.ex (fails due to conflicting kernel method)