### PR TITLE
Upd bitcoind sparrow

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -26,7 +26,7 @@ KEYRINGS_DIR="/etc/apt/keyrings"
 NODEJS_VERSION="20"
 NODEJS_LIST_FILE="${APT_SOURCES_DIR}/nodesource.list"
 NODEJS_KEYRING_FILE="${KEYRINGS_DIR}/nodesource.gpg"
-NPM_UPD_VER="10.9.1"
+NPM_UPD_VER="10.9.2"
 TOR_LIST_FILE="${APT_SOURCES_DIR}/tor.list"
 TOR_KEYRING_FILE="${KEYRINGS_DIR}/tor-archive-keyring.gpg"
 TORRC_CONF_FILE="/etc/tor/torrc"
@@ -104,7 +104,7 @@ THH_SSL_PORT="4001"
 #-----------------------------------------------------------------
 
 # Sparrow config
-SPARROW_VERSION="2.1.2"
+SPARROW_VERSION="2.1.3"
 SPARROW_DIR="${HOME_DIR}/.sparrow"
 SPARROW_DOWNLOAD_DIR="${DOWNLOAD_DIR}/Sparrow"
 SPARROW_CONF_FILE="${SPARROW_DIR}/config"

--- a/install/1_install_bitcoind.sh
+++ b/install/1_install_bitcoind.sh
@@ -191,10 +191,13 @@ zmqpubsequence=tcp://127.0.0.1:28335
 whitelist=127.0.0.1
 
 # Network / tor
-proxy=127.0.0.1:9050
 listen=1
-bind=127.0.0.1
 onlynet=onion
+# Use separate SOCKS5 proxy to reach peers via Tor
+proxy=127.0.0.1:9050
+bind=127.0.0.1
+# allow inbound peers in bitcoin core versions 28+
+bind=127.0.0.1:8334=onion
 
 # Don't let bitcoin core get peers using clearnet dns servers
 dnsseed=0


### PR DESCRIPTION
**Update bitcoin.conf**
- Added missing bind option to allow inbound peers in bitcoin core versions >= 28
  # allow inbound peers in bitcoin core versions 28+
  bind=127.0.0.1:8334=onion
- Changelog: https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-28.0.md#p2p-and-network-changes
- Needs to be added manually into /home/satoshi/.bitcoin/bitcoin.conf in existing installations (restart bitcoind after that)

**Sparrow server from 2.1.2 to 2.1.3**
- Added new version 2.1.3 into CONFIG
- Changelog: https://github.com/sparrowwallet/sparrow/releases/tag/2.1.3
- Use the sparrow upgrade script if you want to update