### PR TITLE
Update 3_install_mempool.sh

### DIFF
--- a/install/3_install_mempool.sh
+++ b/install/3_install_mempool.sh
@@ -240,7 +240,7 @@ npm config set registry=https://registry.npmjs.com/
 # install/build
 cd "${MEMPOOL_DIR}"/rust/gbt
 export PATH="$PATH:/root/.cargo/bin/"
-cargo update
+##cargo update
 cd "${MEMPOOL_BACKEND_DIR}"
 # update npm (based on warnings)
 npm install -g npm@"${NPM_UPD_VER}"


### PR DESCRIPTION
- fix by commenting 'cargo update' line, as the build fails with the newer version the rust setup script installs